### PR TITLE
NICTIZ-18056: created Symptom profile + updated extensions

### DIFF
--- a/Profiles/cio-Condition.xml
+++ b/Profiles/cio-Condition.xml
@@ -346,6 +346,33 @@
         <comment value="Diagnostician" />
       </mapping>
     </element>
+    <element id="Condition.evidence">
+      <path value="Condition.evidence" />
+      <slicing>
+        <discriminator>
+          <type value="profile" />
+          <path value="$this" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Condition.evidence:symptom">
+      <path value="Condition.evidence" />
+      <sliceName value="symptom" />
+    </element>
+    <element id="Condition.evidence:symptom.detail">
+      <path value="Condition.evidence.detail" />
+      <short value="Symptom" />
+      <definition value="A reference to the phenomenon with which a condition in the patient presents itself." />
+      <comment value="Following the functional dataset, the relationship between the Symptom and Condition building blocks is expected to be defined through the Symptom. However, the Symptom building block has been mapped to an Observation resource which does not contain an existing element to reference to a Condition. To avoid the need of an extension, it has been chosen to create a link between the Symptom and Condition through the `Condition.evidence.detail` element." />
+      <alias value="Symptoom" />
+      <min value="1" />
+      <max value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/cio-Symptom" />
+      </type>
+    </element>
     <element id="Condition.note">
       <path value="Condition.note" />
       <max value="1" />

--- a/Profiles/cio-Symptom.xml
+++ b/Profiles/cio-Symptom.xml
@@ -15,12 +15,12 @@
       <use value="work" />
     </telecom>
   </contact>
-  <description value="A symptom is a phenomenon with which a Observation in the patient presents itself. This also includes a complaint or a finding, but not additional research, such as laboratory tests, function tests and imaging studies." />
+  <description value="A symptom is a phenomenon with which a condition in the patient presents itself. This also includes a complaint or a finding, but not additional research, such as laboratory tests, function tests and imaging studies." />
   <purpose value="This Observation resource represents the Symptom related concepts for implementations following the information standard [CiO](https://informatiestandaarden.nictiz.nl/wiki/Landingspagina_Contra-indicaties_en_Overgevoeligheden). This profile is largely based on the Dutch zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Symptom is part of the 2024 prepublication. Therefore it has no dependency on a corresponding nl-core profile and mappings to zib concepts are not defined. Instead mappings to the CiO data set have been added. It is the intention to derive this profile from a more general nl-core-Symptom profile in the future." />
   <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
   <fhirVersion value="4.0.1" />
   <mapping>
-    <identity value="cio-dataset-200-beta2-20231214" />
+    <identity value="cio-dataset-20-20231214" />
     <uri value="https://decor.nictiz.nl/pub/cio/cio-html-20231214T100742/ds-2.16.840.1.113883.2.4.3.11.60.26.1.2-2020-04-02T000000.html" />
     <name value="ART-DECOR Dataset Contraindications and hypersensitivities 2.0.0-beta.2 20231214" />
   </mapping>
@@ -33,39 +33,20 @@
     <element id="Observation">
       <path value="Observation" />
       <short value="Symptom" />
-      <definition value="A phenomenon with which a condition in the patient presents itself." />
-      <comment value="This also includes a complaint or a finding, but not additional research, such as laboratory tests, function tests and imaging studies." />
+      <comment value="This profile is always used together with an instance conforming to [cio-Condition](http://nictiz.nl/fhir/StructureDefinition/cio-Condition) and [cio-Reaction](http://nictiz.nl/fhir/StructureDefinition/cio-Reaction). &#xD;&#xA;&#xD;&#xA;Note that the concept RelationCondition from the Symptom building block is not mapped within this profile. Instead, the relationship between Symptom and Condition is established through the `Condition.evidence.detail` element. Please refer to the [cio-Condition](http://nictiz.nl/fhir/StructureDefinition/cio-Condition) profile for more guidance." />
       <alias value="Symptoom" />
       <mapping>
-        <identity value="cio-dataset-200-beta2-20231214" />
-        <map value="cio-dataset-200-beta2-890" />
+        <identity value="cio-dataset-20-20231214" />
+        <map value="cio-dataset-20-890" />
         <comment value="Symptom" />
       </mapping>
-    </element>
-    <element id="Observation.extension">
-      <path value="Observation.extension" />
-      <min value="1" />
     </element>
     <element id="Observation.extension:medicationHypersensitivityIdentifier">
       <path value="Observation.extension" />
       <sliceName value="medicationHypersensitivityIdentifier" />
       <type>
         <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-MedicationHypersensitivityIdentifier" />
-      </type>
-      <isModifier value="false" />
-    </element>
-    <element id="Observation.extension:medicationHypersensitivityIdentifier.url">
-      <path value="Observation.extension.url" />
-      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/ext-MedicationHypersensitivityIdentifier" />
-    </element>
-    <element id="Observation.extension:relationCondition">
-      <path value="Observation.extension" />
-      <sliceName value="relationCondition" />
-      <min value="1" />
-      <type>
-        <code value="Extension" />
-        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-RelationCondition" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-MedicationHypersensitivity.Identifier" />
       </type>
       <isModifier value="false" />
     </element>
@@ -75,7 +56,7 @@
       <definition value="Globally unique number that identifies the instantiation of the information model. The number is composed of an identification of the issuer organization and a unique number assigned by this organization." />
       <alias value="Identificatienummer" />
       <mapping>
-        <identity value="cio-dataset-200-beta2-20231214" />
+        <identity value="cio-dataset-20-20231214" />
         <map value="cio-dataelement-20-780" />
         <comment value="IdentificationNumber" />
       </mapping>
@@ -91,7 +72,7 @@
         <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.26.11.35--20240501114333" />
       </binding>
       <mapping>
-        <identity value="cio-dataset-200-beta2-20231214" />
+        <identity value="cio-dataset-20-20231214" />
         <map value="cio-dataelement-20-901" />
         <comment value="SymptomName" />
       </mapping>
@@ -102,7 +83,7 @@
       <definition value="More detailed specification of the symptomName that has been selected from the code list, because that list does not (yet) contain the required level of detail." />
       <alias value="NadereSpecificatieSymptoomNaam" />
       <mapping>
-        <identity value="cio-dataset-200-beta2-20231214" />
+        <identity value="cio-dataset-20-20231214" />
         <map value="cio-dataelement-20-902" />
         <comment value="FurtherSpecificationSymptomName" />
       </mapping>
@@ -112,27 +93,8 @@
       <min value="1" />
       <type>
         <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Location" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
       </type>
-    </element>
-    <element id="Observation.interpretation">
-      <path value="Observation.interpretation" />
-      <short value="SymptomSeverity" />
-      <definition value="Indicates the degree of severity of the symptom at the moment of the SymptomStatusDate." />
-      <alias value="SymptomSeverity" />
-      <max value="1" />
-      <binding>
-        <strength value="required" />
-        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.26.11.34--20240501114150" />
-      </binding>
-      <mapping>
-        <identity value="cio-dataset-200-beta2-20231214" />
-        <map value="cio-dataset-200-beta2-898" />
-      </mapping>
     </element>
     <element id="Observation.note">
       <path value="Observation.note" />
@@ -144,9 +106,50 @@
       <definition value="A comment in free text with respect to the symptom, that is not represented by the other data elements in the information model." />
       <alias value="Toelichting" />
       <mapping>
-        <identity value="cio-dataset-200-beta2-20231214" />
+        <identity value="cio-dataset-20-20231214" />
         <map value="cio-dataelement-20-904" />
         <comment value="Comment" />
+      </mapping>
+    </element>
+    <element id="Observation.component">
+      <path value="Observation.component" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="code" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+    </element>
+    <element id="Observation.component:severity">
+      <path value="Observation.component" />
+      <sliceName value="severity" />
+    </element>
+    <element id="Observation.component:severity.code">
+      <path value="Observation.component.code" />
+      <patternCodeableConcept>
+        <coding>
+          <system value="http://snomed.info/sct" />
+          <code value="246112005" />
+        </coding>
+      </patternCodeableConcept>
+    </element>
+    <element id="Observation.component:severity.value[x]">
+      <path value="Observation.component.value[x]" />
+      <short value="SymptomSeverity" />
+      <definition value="Indicates the degree of severity of the symptom at the moment of the SymptomStatusDate." />
+      <alias value="SymptoomErnst" />
+      <type>
+        <code value="CodeableConcept" />
+      </type>
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.26.11.34--20240501114150" />
+      </binding>
+      <mapping>
+        <identity value="cio-dataset-20-20231214" />
+        <map value="cio-dataset-20-898" />
+        <comment value="SymptomSeverity" />
       </mapping>
     </element>
   </differential>

--- a/Profiles/cio-Symptom.xml
+++ b/Profiles/cio-Symptom.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+  <id value="cio-Symptom" />
+  <url value="http://nictiz.nl/fhir/StructureDefinition/cio-Symptom" />
+  <version value="1.0.0-beta.3" />
+  <name value="CioSymptom" />
+  <title value="cio Symptom" />
+  <status value="draft" />
+  <publisher value="Nictiz" />
+  <contact>
+    <name value="Nictiz" />
+    <telecom>
+      <system value="url" />
+      <value value="https://www.nictiz.nl" />
+      <use value="work" />
+    </telecom>
+  </contact>
+  <description value="A symptom is a phenomenon with which a Observation in the patient presents itself. This also includes a complaint or a finding, but not additional research, such as laboratory tests, function tests and imaging studies." />
+  <purpose value="This Observation resource represents the Symptom related concepts for implementations following the information standard [CiO](https://informatiestandaarden.nictiz.nl/wiki/Landingspagina_Contra-indicaties_en_Overgevoeligheden). This profile is largely based on the Dutch zib ('Zorginformatiebouwsteen', i.e. Health and Care Information Model) Symptom is part of the 2024 prepublication. Therefore it has no dependency on a corresponding nl-core profile and mappings to zib concepts are not defined. Instead mappings to the CiO data set have been added. It is the intention to derive this profile from a more general nl-core-Symptom profile in the future." />
+  <copyright value="Copyright and related rights waived via CC0, https://creativecommons.org/publicdomain/zero/1.0/. This does not apply to information from third parties, for example a medical terminology system. The implementer alone is responsible for identifying and obtaining any necessary licenses or authorizations to utilize third party IP in connection with the specification or otherwise." />
+  <fhirVersion value="4.0.1" />
+  <mapping>
+    <identity value="cio-dataset-200-beta2-20231214" />
+    <uri value="https://decor.nictiz.nl/pub/cio/cio-html-20231214T100742/ds-2.16.840.1.113883.2.4.3.11.60.26.1.2-2020-04-02T000000.html" />
+    <name value="ART-DECOR Dataset Contraindications and hypersensitivities 2.0.0-beta.2 20231214" />
+  </mapping>
+  <kind value="resource" />
+  <abstract value="false" />
+  <type value="Observation" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Observation" />
+  <derivation value="constraint" />
+  <differential>
+    <element id="Observation">
+      <path value="Observation" />
+      <short value="Symptom" />
+      <definition value="A phenomenon with which a condition in the patient presents itself." />
+      <comment value="This also includes a complaint or a finding, but not additional research, such as laboratory tests, function tests and imaging studies." />
+      <alias value="Symptoom" />
+      <mapping>
+        <identity value="cio-dataset-200-beta2-20231214" />
+        <map value="cio-dataset-200-beta2-890" />
+        <comment value="Symptom" />
+      </mapping>
+    </element>
+    <element id="Observation.extension">
+      <path value="Observation.extension" />
+      <min value="1" />
+    </element>
+    <element id="Observation.extension:medicationHypersensitivityIdentifier">
+      <path value="Observation.extension" />
+      <sliceName value="medicationHypersensitivityIdentifier" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-MedicationHypersensitivityIdentifier" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Observation.extension:medicationHypersensitivityIdentifier.url">
+      <path value="Observation.extension.url" />
+      <fixedUri value="http://nictiz.nl/fhir/StructureDefinition/ext-MedicationHypersensitivityIdentifier" />
+    </element>
+    <element id="Observation.extension:relationCondition">
+      <path value="Observation.extension" />
+      <sliceName value="relationCondition" />
+      <min value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://nictiz.nl/fhir/StructureDefinition/ext-RelationCondition" />
+      </type>
+      <isModifier value="false" />
+    </element>
+    <element id="Observation.identifier">
+      <path value="Observation.identifier" />
+      <short value="IdentificationNumber" />
+      <definition value="Globally unique number that identifies the instantiation of the information model. The number is composed of an identification of the issuer organization and a unique number assigned by this organization." />
+      <alias value="Identificatienummer" />
+      <mapping>
+        <identity value="cio-dataset-200-beta2-20231214" />
+        <map value="cio-dataelement-20-780" />
+        <comment value="IdentificationNumber" />
+      </mapping>
+    </element>
+    <element id="Observation.code">
+      <path value="Observation.code" />
+      <short value="SymptomName" />
+      <definition value="Name and code of the symptom via selection from a code list. Represents the symptom which a condition in the patient presents itself." />
+      <alias value="SymptoomNaame" />
+      <binding>
+        <strength value="required" />
+        <description value="Identification of the symptom." />
+        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.26.11.35--20240501114333" />
+      </binding>
+      <mapping>
+        <identity value="cio-dataset-200-beta2-20231214" />
+        <map value="cio-dataelement-20-901" />
+        <comment value="SymptomName" />
+      </mapping>
+    </element>
+    <element id="Observation.code.text">
+      <path value="Observation.code.text" />
+      <short value="FurtherSpecificationSymptomName" />
+      <definition value="More detailed specification of the symptomName that has been selected from the code list, because that list does not (yet) contain the required level of detail." />
+      <alias value="NadereSpecificatieSymptoomNaam" />
+      <mapping>
+        <identity value="cio-dataset-200-beta2-20231214" />
+        <map value="cio-dataelement-20-902" />
+        <comment value="FurtherSpecificationSymptomName" />
+      </mapping>
+    </element>
+    <element id="Observation.subject">
+      <path value="Observation.subject" />
+      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Group" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Location" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
+      </type>
+    </element>
+    <element id="Observation.interpretation">
+      <path value="Observation.interpretation" />
+      <short value="SymptomSeverity" />
+      <definition value="Indicates the degree of severity of the symptom at the moment of the SymptomStatusDate." />
+      <alias value="SymptomSeverity" />
+      <max value="1" />
+      <binding>
+        <strength value="required" />
+        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.26.11.34--20240501114150" />
+      </binding>
+      <mapping>
+        <identity value="cio-dataset-200-beta2-20231214" />
+        <map value="cio-dataset-200-beta2-898" />
+      </mapping>
+    </element>
+    <element id="Observation.note">
+      <path value="Observation.note" />
+      <max value="1" />
+    </element>
+    <element id="Observation.note.text">
+      <path value="Observation.note.text" />
+      <short value="Comment" />
+      <definition value="A comment in free text with respect to the symptom, that is not represented by the other data elements in the information model." />
+      <alias value="Toelichting" />
+      <mapping>
+        <identity value="cio-dataset-200-beta2-20231214" />
+        <map value="cio-dataelement-20-904" />
+        <comment value="Comment" />
+      </mapping>
+    </element>
+  </differential>
+</StructureDefinition>

--- a/Profiles/ext-MedicationHypersensitivityIdentifier.xml
+++ b/Profiles/ext-MedicationHypersensitivityIdentifier.xml
@@ -33,6 +33,10 @@
     <type value="element" />
     <expression value="Condition" />
   </context>
+  <context>
+    <type value="element" />
+    <expression value="Observation" />
+  </context>
   <type value="Extension" />
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
   <derivation value="constraint" />

--- a/Profiles/ext-RelationCondition.xml
+++ b/Profiles/ext-RelationCondition.xml
@@ -25,6 +25,10 @@
     <type value="element" />
     <expression value="AllergyIntolerance" />
   </context>
+  <context>
+    <type value="element" />
+    <expression value="Observation" />
+  </context>
   <type value="Extension" />
   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Extension" />
   <derivation value="constraint" />


### PR DESCRIPTION
There is one outstanding item i.e. the addition of SymptomStatusDate. This element is not part of the transaction. However, the definition of SymptomSeverity includes the SymptomStatusDate. This is currently a point of discussion within the team.